### PR TITLE
Update to latest crow, resolve link errors.

### DIFF
--- a/SecurityMiddleware.cpp
+++ b/SecurityMiddleware.cpp
@@ -1,0 +1,41 @@
+#include "SecurityMiddleware.h"
+
+namespace crow {
+    namespace security_middleware {
+        
+        const Sources::TypeMap Sources::kTypeNames = {
+            {Type::DEFAULT, "default-src"},
+            {Type::SCRIPT,	"script-src"},
+            {Type::STYLE,	"style-src"},
+            {Type::CONNECT, "connect-src"},
+            {Type::FONT,	"font-src"},
+            {Type::FRAME,	"frame-src"},
+            {Type::IMG,		"img-src"},
+            {Type::MEDIA,	"media-src"},
+            {Type::OBJECT,	"object-src"}
+        };
+        
+        const std::string Sources::kSelf = "'self'";
+        
+        Sources& Sources::trust(Type type, const std::string& origin) {
+            trustedSources_[type] += " " + origin; /// just combine matching types into single string
+            return *this;
+        }
+        
+        SecurityMiddleware::SecurityMiddleware() {
+            setXFrameOptions(XFrameOptions::SAMEORIGIN)
+            .setXSSProtection(XSSProtection::BLOCK)
+            .setNoSniff();
+        }
+        
+        void SecurityMiddleware::after_handle(const request& req, response& res, context& ctx) {
+            res.set_header("Server", "");
+        }
+        
+        void SecurityMiddleware::before_handle(const request& req, response& res, context& ctx) {
+            for (auto pair : headers_) {
+                res.add_header(pair.first, pair.second);
+            }
+        }
+    }
+}

--- a/SecurityMiddleware.cpp
+++ b/SecurityMiddleware.cpp
@@ -1,0 +1,41 @@
+#include "SecurityMiddleware.h"
+
+namespace crow {
+	namespace security_middleware {
+		
+		const Sources::TypeMap Sources::kTypeNames = {
+			{Type::DEFAULT, "default-src"},
+			{Type::SCRIPT,	"script-src"},
+			{Type::STYLE,	"style-src"},
+			{Type::CONNECT, "connect-src"},
+			{Type::FONT,	"font-src"},
+			{Type::FRAME,	"frame-src"},
+			{Type::IMG,		"img-src"},
+			{Type::MEDIA,	"media-src"},
+			{Type::OBJECT,	"object-src"}
+		};
+		
+		const std::string Sources::kSelf = "'self'";
+
+		Sources& Sources::trust(Type type, const std::string& origin) {
+			trustedSources_[type] += " " + origin; /// just combine matching types into single string
+			return *this;
+		}
+		
+		SecurityMiddleware::SecurityMiddleware() {
+			setXFrameOptions(XFrameOptions::SAMEORIGIN)
+			.setXSSProtection(XSSProtection::BLOCK)
+			.setNoSniff();
+		}
+		
+		void SecurityMiddleware::after_handle(const request& req, response& res, context& ctx) {
+			res.set_header("Server", "");
+		}
+		
+		void SecurityMiddleware::before_handle(const request& req, response& res, context& ctx) {
+			for (auto pair : headers_) {
+				res.add_header(pair.first, pair.second);
+			}
+		}
+	}
+}

--- a/SecurityMiddleware.h
+++ b/SecurityMiddleware.h
@@ -41,10 +41,7 @@ namespace crow {
 			static const std::string kSelf; ///< "'self'" for use as an origin.
 			
 			/// Trust this origin to supply the specified content type.
-			Sources& trust(Type type, const std::string& origin = kSelf) {
-				trustedSources_[type] += " " + origin; /// just combine matching types into single string
-				return *this;
-			}
+			Sources& trust(Type type, const std::string& origin = kSelf);
 		private:
 			using TypeMap = std::unordered_map<Type, std::string>;
 			static const TypeMap kTypeNames;
@@ -66,16 +63,15 @@ namespace crow {
 		/// \code
 		/// SecurityMiddleware().setXFrameOptions(XFrameOptions::BLOCK).setNoSniff()
 		/// \endcode
-		class SecurityMiddleware : public IMiddleware {
+		class SecurityMiddleware {
 		public:
+			struct context {
+			};
+			
 #pragma mark - Create Instance
 			/// Create a new SecurityMiddleware instance with some reasonable defaults.
 			/// Intended just as a starting point - be sure to set up HSTS, Content Security Policy, etc.
-			SecurityMiddleware() {
-				setXFrameOptions(XFrameOptions::SAMEORIGIN)
-				.setXSSProtection(XSSProtection::BLOCK)
-				.setNoSniff();
-			}
+			SecurityMiddleware();
 			
 #pragma mark - X-Frame-Options
 			/// Set the X-Frame-Options header to tell browsers not to render our site as an iframe in a different domain (prevent clickjacking)
@@ -149,34 +145,13 @@ namespace crow {
 				return *this;
 			}
 			
-			// TODO - Disable the 'Server: Crow/0.1' header
-			
 #pragma mark - Handle Request
-			void after_handle(const request& req, response& res) {}
+			void after_handle(const request& req, response& res, context& ctx);
 			
-			void before_handle(const request& req, response& res) {
-				for (auto pair : headers_) {
-					res.headers[pair.first] = pair.second;
-				}
-				res.headers.erase("Server");
-			}
+			void before_handle(const request& req, response& res, context& ctx);
 			
 		private:
 			Headers headers_;
 		};
-		
-		const Sources::TypeMap Sources::kTypeNames = {
-			{Type::DEFAULT, "default-src"},
-			{Type::SCRIPT,	"script-src"},
-			{Type::STYLE,	"style-src"},
-			{Type::CONNECT, "connect-src"},
-			{Type::FONT,	"font-src"},
-			{Type::FRAME,	"frame-src"},
-			{Type::IMG,		"img-src"},
-			{Type::MEDIA,	"media-src"},
-			{Type::OBJECT,	"object-src"}
-		};
-		
-		const std::string Sources::kSelf = "'self'";
 	}
 }


### PR DESCRIPTION
This resolves compatibility issues on the (as of writing) latest version of crow, and resolves linker errors related to the kTypeNames and kSelf variables on Apple LLVM 6.0/clang 3.5 (OS X 10.10.1, Xcode 6.1.1).

This also resolves the TODO of disabling the 'Server' header by setting it to an empty string in after_handle.

Figured I'd make a PR here, this seems like a nice little middleware for Crow.  I hate to see it fall behind!
